### PR TITLE
chore: add useRoute composable.

### DIFF
--- a/runtime/composables.mjs
+++ b/runtime/composables.mjs
@@ -1,1 +1,2 @@
 export const useNuxtApp = () => ({});
+export const useRoute = () => ({query: {}, matched: [], fullPath: '', hash: '', path: '', params: {}, meta: {}});

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -75,7 +75,7 @@ async function useNuxtViteConfig() {
   });
 
   nuxt.hook('imports:sources', (presets) => {
-    const stubbedComposables = ['useNuxtApp'];
+    const stubbedComposables = ['useNuxtApp', 'useRoute'];
     const appPreset = presets.find((p) => p.from === '#app');
     if (appPreset) {
       appPreset.imports = appPreset.imports.filter(


### PR DESCRIPTION
This pull request adds the useRoute composable to the storybook runtime, so it can be used in Vue components outside of Nuxt.

This is useful for when you want to include bigger components in your storybook.